### PR TITLE
Google plus dead

### DIFF
--- a/extra/did_you_feel_it/README.md
+++ b/extra/did_you_feel_it/README.md
@@ -24,7 +24,6 @@ This sample uses the Gradle build system. To build this project, use the
 Support
 -------
 
-- Google+ Community: https://plus.google.com/communities/105153134372062985968
 - Stack Overflow: http://stackoverflow.com/questions/tagged/android
 
 Patches are encouraged, and may be submitted by forking this project and


### PR DESCRIPTION
Google plus is dead - those links can be removed because they also don't work.